### PR TITLE
Make distro conditional more flexible

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Install epel on your system.
 
 ## [Example Playbook](#example-playbook)
 
-This example is taken from `molecule/resources/converge.yml` and is tested on each push, pull request and release.
+This example is taken from `molecule/default/converge.yml` and is tested on each push, pull request and release.
 ```yaml
 ---
 - name: Converge
@@ -20,7 +20,7 @@ This example is taken from `molecule/resources/converge.yml` and is tested on ea
     - role: robertdebock.epel
 ```
 
-The machine needs to be prepared in CI this is done using `molecule/resources/prepare.yml`:
+The machine needs to be prepared in CI this is done using `molecule/default/prepare.yml`:
 ```yaml
 ---
 - name: Prepare

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -2,7 +2,7 @@
 galaxy_info:
   author: Robert de Bock
   namespace: robertdebock
-  ansible_role: epel
+  role_name: epel
   description: Install epel on your system.
   license: Apache-2.0
   company: none

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -17,5 +17,5 @@
   when:
     - (ansible_distribution == "Amazon" and
       ansible_distribution_major_version == "2") or
-      (ansible_os_family == "RedHat" and
+      (ansible_os_family in [ "RedHat", "Rocky" ] and
       ansible_distribution_major_version in [ "7", "8" ])

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -17,5 +17,5 @@
   when:
     - (ansible_distribution == "Amazon" and
       ansible_distribution_major_version == "2") or
-      (ansible_distribution in [ "CentOS", "RedHat", "Rocky" ] and
+      (ansible_os_family == "RedHat" and
       ansible_distribution_major_version in [ "7", "8" ])


### PR DESCRIPTION
- Regenerate README
- Make distro conditional more flexible

**Describe the change**
I changed `ansible_distribution in [ "CentOS", "RedHat", "Rocky" ]` >
`ansible_os_family == "RedHat"`. I did this after I noticed this role
doesn't work on Almalinux. I think this is better than just adding
`Almalinux` to the array, as it makes this role automatically compatible
with all RHEL clones without us having to list them manually.
