### PR TITLE
Install epel-next on CentOS Stream and other minor fixes. 

### DIFF
--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -36,6 +36,8 @@ jobs:
           - image: "amazonlinux"
             tag: "latest"
           - image: "enterpriselinux"
+            tag: "7"
+          - image: "enterpriselinux"
             tag: "latest"
     steps:
       - name: checkout

--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           path: "${{ github.repository }}"
       - name: molecule
-        uses: robertdebock/molecule-action@4.0.7
+        uses: robertdebock/molecule-action@4.0.6
         with:
           command: lint
   test:
@@ -47,7 +47,7 @@ jobs:
       - name: parse apparmor for mysql
         run: sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
       - name: molecule
-        uses: robertdebock/molecule-action@4.0.7
+        uses: robertdebock/molecule-action@4.0.6
         with:
           image: ${{ matrix.config.image }}
           tag: ${{ matrix.config.tag }}

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,5 @@
 ---
-image: "robertdebock/github-action-molecule:4.0.6"
+image: "robertdebock/github-action-molecule:4.0.5"
 
 services:
   - docker:dind

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -19,6 +19,8 @@ molecule:
       - image: "amazonlinux"
         tag: "latest"
       - image: "enterpriselinux"
+        tag: "7"
+      - image: "enterpriselinux"
         tag: "latest"
 
 galaxy:

--- a/README.md
+++ b/README.md
@@ -34,6 +34,17 @@ The machine needs to be prepared. In CI this is done using `molecule/default/pre
 
 Also see a [full explanation and example](https://robertdebock.nl/how-to-use-these-roles.html) on how to use these roles.
 
+## [Role Variables](#role-variables)
+
+The default values for the variables are set in `defaults/main.yml`:
+```yaml
+---
+# defaults file for epel
+
+# Whether to install the new `epel-next` repository. This is only installed
+# by default on CentOS Stream, as per https://docs.fedoraproject.org/en-US/epel/#_quickstart.
+epel_next: "{{ yes if ansible_distribution_release == 'Stream' }}"
+```
 
 ## [Requirements](#requirements)
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ This role has been tested on these [container images](https://hub.docker.com/u/r
 |container|tags|
 |---------|----|
 |amazon|Candidate|
-|el|8|
+|el|7, 8|
 
 The minimum version of Ansible required is 2.10, tests have been done to:
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,0 +1,6 @@
+---
+# defaults file for epel
+
+# Whether to install the new `epel-next` repository. This is only installed
+# by default on CentOS Stream, as per https://docs.fedoraproject.org/en-US/epel/#_quickstart.
+epel_next: "{{ yes if ansible_distribution_release == 'Stream' }}"

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,6 +1,6 @@
 ---
 # handlers file for epel
 
-- name: yum update cache
-  ansible.builtin.yum:
+- name: update package cache
+  ansible.builtin.package:
     update_cache: yes

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -14,6 +14,7 @@ galaxy_info:
         - Candidate
     - name: EL
       versions:
+        - 7
         - 8
 
   galaxy_tags:

--- a/tasks/assert.yml
+++ b/tasks/assert.yml
@@ -1,0 +1,7 @@
+---
+- name: Ensure that `epel_next` is set correctly.
+  ansible.builtin.assert:
+    quiet: yes
+    that:
+      - epel_next is defined
+      - epel_next is bool

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,7 +13,15 @@
         name: "{{ epel_url }}"
         state: present
       notify:
-        - yum update cache
+        - update package cache
+
+    - name: install epel-next-release
+      ansible.builtin.package:
+        name: "{{ epel_next_url }}"
+        state: present
+      when: epel_next | bool
+      notify:
+        - update package cache
   when:
     - (ansible_distribution == "Amazon" and
       ansible_distribution_major_version == "2") or

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -17,5 +17,5 @@
   when:
     - (ansible_distribution == "Amazon" and
       ansible_distribution_major_version == "2") or
-      (ansible_os_family in [ "RedHat", "Rocky" ] and
+      (ansible_os_family == "RedHat" and
       ansible_distribution_major_version in [ "7", "8" ])

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -10,4 +10,6 @@ epel_version: "{{ _epel_version[ansible_distribution ~ '-' ~ ansible_distributio
 
 epel_url: "https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ epel_version }}.noarch.rpm"
 
+epel_next_url: "https://dl.fedoraproject.org/pub/epel/epel-next-release-latest-{{ epel_version }}.noarch.rpm"
+
 epel_gpg_key: "https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-{{ epel_version }}"


### PR DESCRIPTION
---
name: Install epel-next on CentOS Stream and other minor fixes. 
about: In line with the CentOS Stream change, EPEL Next was introduced which rebuilds certain EPEL packages for CentOS Stream. See the [EPEL documentation](https://docs.fedoraproject.org/en-US/epel/#what_is_epel_next) for more info.

---

**Describe the change**
This change introduces a new option, `epel_next`. It determines whether the role will install the epel-next repository. By default, the var is set to `true` on CentOS Stream and `false` on other EL distributions, but it can be turned on unconditionally or not at all by changing the default value.

**Testing**
I tested this role on CentOS Stream to confirm it installed epel-next by default and ran it again on Almalinux 8 to ensure that it maintained the old behavior (only installed regular epel).
